### PR TITLE
Update energy.service

### DIFF
--- a/etc/systemd/system/energy.service
+++ b/etc/systemd/system/energy.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c 'for i in {0..7}; do echo power | sudo tee /sys/devices/system/cpu/cpu$i/cpufreq/energy_performance_preference; done'
+ExecStart=/bin/bash -c 'for i in {0..7}; do echo balance_power | sudo tee /sys/devices/system/cpu/cpu$i/cpufreq/energy_performance_preference; echo 400000 | sudo tee /sys/devices/system/cpu/cpu$i/cpufreq/scaling_min_freq; done'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Change the epp to balance_power to avoid stuttering 
Change min frequency to lowest frequency possible on Steam D.eck.
Allows the cpu to decrease frequency in cores where its possible.

Tested on Steam Deck LCD.